### PR TITLE
Add basic support for command line arguments

### DIFF
--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2025, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "CLI.hpp"
+
+#include "getopt.h"
+
+#include <iostream>
+#include <cstring>
+#include <cassert>
+
+namespace{
+void printUsage() {
+    std::cout <<
+        "Usage: hornix [options] [-i] file\n"
+        "\n"
+        "-h,--help                  Print this help message\n"
+        "--version                  Print version number of Hornix\n"
+        "-i,--input <file>          Input file (option not required)\n"
+        "--print-chc                Dump CHC to standard output and exit\n"
+        "--solver <solver>          Horn solver to run: z3, golem, eldarica (default: z3)\n"
+        ;
+    std::cout << std::flush;
+}
+
+bool isDisableKeyword(const char* word) {
+    return strcmp(word, "no") == 0 or strcmp(word, "false") == 0 or strcmp(word, "disable") == 0;
+}
+}
+
+namespace hornix {
+
+const std::string Options::INPUT_FILE = "input";
+const std::string Options::PRINT_CHC = "print-chc";
+const std::string Options::SOLVER = "solver";
+
+Options parse(int argc, char ** argv) {
+
+    Options res;
+    int printVersion = 0;
+    int printChc = 0;
+    std::string solver = "z3";
+
+    struct option long_options[] =
+        {
+            {"help", no_argument, nullptr, 'h'},
+            {Options::INPUT_FILE.c_str(), required_argument, nullptr, 'i'},
+            {Options::PRINT_CHC.c_str(), no_argument, &printChc, 1},
+            {Options::SOLVER.c_str(), required_argument, nullptr, 0},
+            {"version", no_argument, &printVersion, 1},
+            {0, 0, 0, 0}
+        };
+
+    while (true) {
+        int option_index = 0;
+
+        int c = getopt_long(argc, argv, "i:h", long_options, &option_index);
+        if (c == -1) { break; }
+
+        switch (c) {
+            case 0:
+                if (long_options[option_index].flag == &printVersion) {
+                    std::cout << "Hornix " << "0.1.0" << std::endl;
+                    exit(0);
+                }
+                if (strcmp(long_options[option_index].name, Options::SOLVER.c_str()) == 0) {
+                    res.addOption(Options::SOLVER, optarg);
+                }
+                break;
+            case 'h':
+                printUsage();
+                exit(0);
+            case 'i':
+                res.addOption(Options::INPUT_FILE, optarg);
+                break;
+            default:
+                abort();
+        }
+    }
+    if (optind < argc) {
+        if (optind < argc - 1) {
+            std::cerr << "Error in parsing the command line argument" << '\n';
+            printUsage();
+            exit(1);
+        }
+        // Assume the last argument not assigned to any option is input file
+        res.addOption("input", argv[optind]);
+    }
+    if (printChc) {
+        res.addOption("print-chc", "true");
+    }
+    return res;
+}
+
+} // namespace hornix

--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -21,7 +21,9 @@ void printUsage() {
         "--version                  Print version number of Hornix\n"
         "-i,--input <file>          Input file (option not required)\n"
         "--print-chc                Dump CHC to standard output and exit\n"
-        "--solver <solver>          Horn solver to run: z3, golem, eldarica (default: z3)\n"
+        "--solver <solver>          Horn solver to run (default: z3)\n"
+        "--solver-dir='<dir>'       Directory with the chosen solver's executable\n"
+        "--solver-args='<args>'     Arguments to pass to the chosen solver\n"
         ;
     std::cout << std::flush;
 }
@@ -36,13 +38,14 @@ namespace hornix {
 const std::string Options::INPUT_FILE = "input";
 const std::string Options::PRINT_CHC = "print-chc";
 const std::string Options::SOLVER = "solver";
+const std::string Options::SOLVER_ARGS = "solver-args";
+const std::string Options::SOLVER_DIR = "solver-dir";
 
 Options parse(int argc, char ** argv) {
 
     Options res;
     int printVersion = 0;
     int printChc = 0;
-    std::string solver = "z3";
 
     struct option long_options[] =
         {
@@ -50,6 +53,8 @@ Options parse(int argc, char ** argv) {
             {Options::INPUT_FILE.c_str(), required_argument, nullptr, 'i'},
             {Options::PRINT_CHC.c_str(), no_argument, &printChc, 1},
             {Options::SOLVER.c_str(), required_argument, nullptr, 0},
+            {Options::SOLVER_DIR.c_str(), required_argument, nullptr, 0},
+            {Options::SOLVER_ARGS.c_str(), required_argument, nullptr, 0},
             {"version", no_argument, &printVersion, 1},
             {0, 0, 0, 0}
         };
@@ -68,6 +73,12 @@ Options parse(int argc, char ** argv) {
                 }
                 if (strcmp(long_options[option_index].name, Options::SOLVER.c_str()) == 0) {
                     res.addOption(Options::SOLVER, optarg);
+                }
+                if (strcmp(long_options[option_index].name, Options::SOLVER_DIR.c_str()) == 0) {
+                    res.addOption(Options::SOLVER_DIR, optarg);
+                }
+                if (strcmp(long_options[option_index].name, Options::SOLVER_ARGS.c_str()) == 0) {
+                    res.addOption(Options::SOLVER_ARGS, optarg);
                 }
                 break;
             case 'h':

--- a/src/CLI.hpp
+++ b/src/CLI.hpp
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2025, Martin Blicha <martin.blicha@gmail.com>
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef CLI_HPP
+#define CLI_HPP
+
+#include <map>
+#include <string>
+
+namespace hornix {
+
+class Options {
+    std::map<std::string, std::string> options;
+public:
+    void addOption(std::string key, std::string value) {
+        options.emplace(std::move(key), std::move(value));
+    }
+
+    [[nodiscard]] std::optional<std::string> getOption(std::string const & key) const {
+        auto it = options.find(key);
+        return it == options.end() ? std::nullopt : std::optional<std::string>(it->second);
+    }
+
+    [[nodiscard]] std::string getOrDefault(std::string const & key, std::string const & def) const {
+        auto it = options.find(key);
+        return it == options.end() ? def : it->second;
+    }
+
+    [[nodiscard]] bool hasOption(std::string const & key) const {
+        auto it = options.find(key);
+        return it != options.end();
+    }
+
+    static const std::string INPUT_FILE;
+    static const std::string PRINT_CHC;
+    static const std::string SOLVER;
+};
+
+Options parse(int argc, char * argv[]);
+
+} // namespace hornix
+#endif //CLI_HPP

--- a/src/CLI.hpp
+++ b/src/CLI.hpp
@@ -37,6 +37,8 @@ public:
     static const std::string INPUT_FILE;
     static const std::string PRINT_CHC;
     static const std::string SOLVER;
+    static const std::string SOLVER_ARGS;
+    static const std::string SOLVER_DIR;
 };
 
 Options parse(int argc, char * argv[]);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(hornix main.cpp)
 
 target_sources(hornix
         PRIVATE
+        "CLI.cpp"
         "Preprocessing.cpp"
         "chc/ChcTransform.cpp"
         "chc/SMTOut.cpp"

--- a/src/chc/Backend.cpp
+++ b/src/chc/Backend.cpp
@@ -20,10 +20,21 @@ namespace hornix {
 SolverContext SolverContext::z3_default() {
     return {
     .solver = "z3",
-    .solver_dir = std::nullopt,
-    .args = {}
+    .args = {},
+    .solver_dir = std::nullopt
     };
 }
+
+SolverContext SolverContext::context_for_solver(std::string solver_name, std::optional<std::string> solver_args, std::optional<std::string> solver_dir) {
+    return {
+        .solver = std::move(solver_name),
+        .solver_dir = std::move(solver_dir),
+        .args = std::move(solver_args).value_or("")
+    };
+}
+
+
+
 Result solve(std::string query) {
     return solve(std::move(query), SolverContext::z3_default());
 }

--- a/src/chc/Backend.hpp
+++ b/src/chc/Backend.hpp
@@ -17,6 +17,7 @@ struct SolverContext {
   std::string args;
 
   static SolverContext z3_default();
+  static SolverContext context_for_solver(std::string solver_name, std::optional<std::string> solver_args, std::optional<std::string> solver_dir);
 };
 
 using Result = std::string;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Preprocessing.hpp"
+#include "CLI.hpp"
 #include "chc/Backend.hpp"
 #include "chc/ChcTransform.hpp"
 #include "chc/SMTOut.hpp"
@@ -19,12 +20,10 @@
 using namespace hornix;
 
 int main(int argc, char * argv[]) {
-    if (argc <= 1)
-    {
-        std::cerr << "Provide an input file!" << std::endl;
-        exit(1);
-    }
-    llvm::StringRef filename = argv[1];
+
+    Options options = parse(argc, argv);
+    assert(options.hasOption(Options::INPUT_FILE));
+    llvm::StringRef filename = options.getOption(Options::INPUT_FILE).value();
 
     llvm::LLVMContext context;
     llvm::SMDiagnostic err;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,13 +45,13 @@ int main(int argc, char * argv[]) {
     std::stringstream query_stream;
     SMTOutput{query_stream}.smt_print_implications(chcs);
 
-    // SolverContext solver_context {
-    // .solver = "golem",
-    // .solver_dir = "/Users/blishko/projects/golem/build",
-    // .args = {}
-    // };
-    // auto res = solve(query_stream.str(), std::move(solver_context));
-    auto res = solve(query_stream.str());
+    auto res = solve(query_stream.str(),
+        SolverContext::context_for_solver(
+            options.getOrDefault(Options::SOLVER, std::string("z3")),
+            options.getOption(Options::SOLVER_ARGS),
+            options.getOption(Options::SOLVER_DIR)
+        )
+    );
     std::cout << res << std::endl;
 
     return 0;


### PR DESCRIPTION
We add a few basic arguments to the program: help, version, the ability to choose and configure Horn solver, and the ability to dump CHC.