### PR TITLE
Improve encoding and preprocessing

### DIFF
--- a/src/Preprocessing.cpp
+++ b/src/Preprocessing.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Transforms/Scalar/SimplifyCFG.h"
 #include "llvm/Transforms/Utils/Mem2Reg.h"
 #include "llvm/Transforms/Utils/InstructionNamer.h"
 
@@ -34,6 +35,7 @@ std::unique_ptr<Module> transform(std::unique_ptr<Module> module) {
     // Build a function pass manager that runs mem2reg
     FunctionPassManager FPM;
     FPM.addPass(PromotePass()); // mem2reg
+    FPM.addPass(SimplifyCFGPass()); //simplifycfg
     FPM.addPass(InstructionNamerPass()); // instnamer, should always be last
 
     // Run the function pass manager over each function

--- a/src/chc/Helpers.cpp
+++ b/src/chc/Helpers.cpp
@@ -2,43 +2,52 @@
 
 namespace hornix {
 // TODO: Implement this as a visitor
-std::set<MyVariable> all_vars(Implication const & implication) {
-    std::set<MyVariable> vars;
+
+using vars_t = std::set<MyVariable>;
+void collect_vars(MyConstraint const * constraint, vars_t & vars) {
     auto process = [&](MyVariable const & var) {
         if (not var.isConstant) {
             vars.insert(var);
         }
     };
-    for (auto const & var : implication.head.vars) {
-        process(var);
-    }
-    for (auto const & constraint : implication.constraints) {
-        if (MyPredicate * pred = dynamic_cast<MyPredicate *>(constraint.get())) {
-            for (auto const & var : pred->vars) {
-                process(var);
-            }
-        } else if (auto * equality = dynamic_cast<Equality *>(constraint.get())) {
-            process(equality->lhs);
-            process(equality->rhs);
-        } else if (auto * unary = dynamic_cast<UnaryConstraint *>(constraint.get())) {
-            process(unary->result);
-            process(unary->value);
-        } else if (auto * binary = dynamic_cast<BinaryConstraint *>(constraint.get())) {
-            process(binary->result);
-            process(binary->operand1);
-            process(binary->operand2);
-        } else if (auto * cmp = dynamic_cast<ComparisonConstraint *>(constraint.get())) {
-            process(cmp->operand1);
-            process(cmp->operand2);
-        } else if (auto * ite = dynamic_cast<ITEConstraint *>(constraint.get())) {
-            process(ite->result);
-            process(ite->condition);
-            process(ite->operand1);
-            process(ite->operand2);
-        } else {
-            throw std::logic_error("Unhandled constraint type!");
+    if (MyPredicate const * pred = dynamic_cast<MyPredicate const *>(constraint)) {
+        for (auto const & var : pred->vars) {
+            process(var);
         }
+    } else if (auto * equality = dynamic_cast<Equality const *>(constraint)) {
+        process(equality->lhs);
+        process(equality->rhs);
+    } else if (auto * unary = dynamic_cast<UnaryConstraint const *>(constraint)) {
+        process(unary->result);
+        process(unary->value);
+    } else if (auto * binary = dynamic_cast<BinaryConstraint const *>(constraint)) {
+        process(binary->result);
+        process(binary->operand1);
+        process(binary->operand2);
+    } else if (auto * cmp = dynamic_cast<ComparisonConstraint const *>(constraint)) {
+        process(cmp->operand1);
+        process(cmp->operand2);
+    } else if (auto * ite = dynamic_cast<ITEConstraint const *>(constraint)) {
+        process(ite->result);
+        process(ite->condition);
+        process(ite->operand1);
+        process(ite->operand2);
+    } else if (auto * neg = dynamic_cast<Not const *>(constraint)) {
+        collect_vars(neg->inner.get(), vars);
+    } else if (auto * conj = dynamic_cast<And const *>(constraint)) {
+        for (auto const & arg : conj->args) {
+            collect_vars(arg.get(), vars);
+        }
+    } else {
+        throw std::logic_error("Unhandled constraint type!");
+    }
+}
 
+std::set<MyVariable> all_vars(Implication const & implication) {
+    std::set<MyVariable> vars;
+    collect_vars(&implication.head, vars);
+    for (auto const & constraint : implication.constraints) {
+        collect_vars(constraint.get(), vars);
     }
     return vars;
 }

--- a/src/chc/Helpers.hpp
+++ b/src/chc/Helpers.hpp
@@ -54,7 +54,7 @@ inline bool operator<(MyVariable const & first, MyVariable const & second) { ret
 
 struct MyConstraint {
     virtual ~MyConstraint() {}
-    virtual std::string Print() const = 0;
+    virtual std::string Print() const { throw std::logic_error("Missing implementation of Print!"); }
     virtual MyPredicateType GetType() const = 0;
     virtual std::string GetSMT() const = 0;
 };
@@ -196,8 +196,6 @@ struct And : MyConstraint {
     ~And() override = default;
     explicit And(std::vector<std::unique_ptr<MyConstraint>> args) : args(std::move(args)) {}
 
-    // [[nodiscard]] std::string Print() const override { return "not(" + inner->Print() + ")"; }
-
     [[nodiscard]] std::string GetSMT() const override {
         std::stringstream ss;
         ss << "(and ";
@@ -252,8 +250,6 @@ struct MyBasicBlock {
     std::vector<std::uint8_t> predecessors;
     // List of ids of successors of basic block
     std::vector<std::uint8_t> successors;
-    // Reference to last br instruction of basic block
-    llvm::Instruction const * last_instruction;
     // True if block calls assert function and fails
     bool isFalseBlock;
     // True if it contains return instruction
@@ -265,7 +261,6 @@ struct MyBasicBlock {
         : BB_link(BB_link_),
           name(std::move(name_)),
           id(id_),
-          last_instruction(nullptr),
           isFalseBlock(false),
           isLastBlock(false),
           isFunctionCalled(false) {}


### PR DESCRIPTION
We enable additional preprocessing pass, `simplifycfg`, which tries to simplify the CFG of a function, reducing the number of basic blocks.
To enable this transformation, we add support for the `switch` instruction in the LLVM IR.